### PR TITLE
Fixes the switch use case to adhere to the open/closed principle

### DIFF
--- a/src/main/java/data_access/DBTranslateTextDataAccessObject.java
+++ b/src/main/java/data_access/DBTranslateTextDataAccessObject.java
@@ -222,6 +222,9 @@ public class DBTranslateTextDataAccessObject implements TranslateTextDataAccessI
     public Map<String, String> switchLanguagesAndTexts(String inputText, String inputLanguage, String outputLanguage)
             throws DataAccessException {
         // translating the text using the translateText method
+        final LanguageMapperInterface outputlanguageClass = GetLanguageClass.giveOutputLanguageClass(inputLanguage);
+        final LanguageMapperInterface inputlanguageClass = GetLanguageClass.giveInputLanguageClass(outputLanguage);
+
         final Map<String, String> translationResult = translateText(inputText, inputLanguage, outputLanguage);
 
         // Getting the translated text
@@ -231,41 +234,14 @@ public class DBTranslateTextDataAccessObject implements TranslateTextDataAccessI
 
         // switching.
         final Map<String, String> switchedResult = new HashMap<>();
+
         switchedResult.put(Constants.TEXT_KEY, translatedText);
 
-        if ("English (British)".equals(outputLanguage) || "English (American)".equals(outputLanguage)) {
-            final String newOutputLanguage = new String("English");
-            switchedResult.put(Constants.LANGUAGE_KEY, newOutputLanguage);
-        }
-        else if ("Portuguese (Brazilian)".equals(outputLanguage) || "Portuguese (European)".equals(outputLanguage)) {
-            final String newOutputLanguage = new String("Portuguese");
-            switchedResult.put(Constants.LANGUAGE_KEY, newOutputLanguage);
-        }
-        else if ("Chinese (simplified)".equals(outputLanguage)) {
-            final String newOutputLanguage = new String("Chinese");
-            switchedResult.put(Constants.LANGUAGE_KEY, newOutputLanguage);
-        }
-        else {
-            switchedResult.put(Constants.LANGUAGE_KEY, outputLanguage);
-        }
+        switchedResult.put(Constants.LANGUAGE_KEY, inputlanguageClass.giveInput(outputLanguage));
 
         switchedResult.put("translatedText", inputText);
 
-        if ("English".equals(inputLanguage)) {
-            final String newInputLanguage = new String("English (American)");
-            switchedResult.put("outputLanguage", newInputLanguage);
-        }
-        else if ("Chinese".equals(inputLanguage)) {
-            final String newInputLanguage = new String("Chinese (simplified)");
-            switchedResult.put("outputLanguage", newInputLanguage);
-        }
-        else if ("Portuguese".equals(inputLanguage)) {
-            final String newInputLanguage = new String("Portuguese (Brazilian)");
-            switchedResult.put("outputLanguage", newInputLanguage);
-        }
-        else {
-            switchedResult.put("outputLanguage", inputLanguage);
-        }
+        switchedResult.put("outputLanguage", outputlanguageClass.giveOutput(inputLanguage));
 
         return switchedResult;
     }

--- a/src/main/java/data_access/GetLanguageClass.java
+++ b/src/main/java/data_access/GetLanguageClass.java
@@ -1,0 +1,209 @@
+package data_access;
+
+import languageClasses.*;
+
+/**
+ * LanguageMapper
+ */
+
+public class GetLanguageClass {
+    /**
+     * @param inputLanguage the language name of text (ie. English).
+     */
+
+    public static LanguageMapperInterface giveOutputLanguageClass(String inputLanguage) {
+        LanguageMapperInterface result = null;
+
+        if ("Bulgarian".equals(inputLanguage)) {
+            result = new Bulgarian();
+        }
+        else if ("Chinese".equals(inputLanguage)) {
+            result = new Chinese();
+        }
+        else if ("Czech".equals(inputLanguage)) {
+            result = new Czech();
+        }
+        else if ("Danish".equals(inputLanguage)) {
+            result = new Danish();
+        }
+        else if ("Dutch".equals(inputLanguage)) {
+            result = new Dutch();
+        }
+        else if ("English".equals(inputLanguage)) {
+            result = new English();
+        }
+        else if ("Estonian".equals(inputLanguage)) {
+            result = new Estonian();
+        }
+        else if ("Finnish".equals(inputLanguage)) {
+            result = new Finnish();
+        }
+        else if ("French".equals(inputLanguage)) {
+            result = new French();
+        }
+        else if ("German".equals(inputLanguage)) {
+            result = new German();
+        }
+        else if ("Greek".equals(inputLanguage)) {
+            result = new Greek();
+        }
+        else if ("Hungarian".equals(inputLanguage)) {
+            result = new Hungarian();
+        }
+        else if ("Indonesian".equals(inputLanguage)) {
+            result = new Indonesian();
+        }
+        else if ("Italian".equals(inputLanguage)) {
+            result = new Italian();
+        }
+        else if ("Japanese".equals(inputLanguage)) {
+            result = new Japanese();
+        }
+        else if ("Korean".equals(inputLanguage)) {
+            result = new Korean();
+        }
+        else if ("Latvian".equals(inputLanguage)) {
+            result = new Latvian();
+        }
+        else if ("Lithuanian".equals(inputLanguage)) {
+            result = new Lithuanian();
+        }
+        else if ("Norwegian".equals(inputLanguage)) {
+            result = new Norwegian();
+        }
+        else if ("Polish".equals(inputLanguage)) {
+            result = new Polish();
+        }
+        else if ("Portuguese".equals(inputLanguage)) {
+            result = new Portuguese();
+        }
+        else if ("Romanian".equals(inputLanguage)) {
+            result = new Romanian();
+        }
+        else if ("Russian".equals(inputLanguage)) {
+            result = new Russian();
+        }
+        else if ("Slovak".equals(inputLanguage)) {
+            result = new Slovak();
+        }
+        else if ("Slovenian".equals(inputLanguage)) {
+            result = new Slovenian();
+        }
+        else if ("Spanish".equals(inputLanguage)) {
+            result = new Spanish();
+        }
+        else if ("Swedish".equals(inputLanguage)) {
+            result = new Swedish();
+        }
+        else if ("Turkish".equals(inputLanguage)) {
+            result = new Turkish();
+        }
+        else if ("Ukrainian".equals(inputLanguage)) {
+            result = new Ukrainian();
+        }
+        return result;
+    }
+
+    /**
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated.
+     */
+    public static LanguageMapperInterface giveInputLanguageClass(String outputLanguage) {
+
+        LanguageMapperInterface result2 = null;
+
+        if ("Bulgarian".equals(outputLanguage)) {
+            result2 = new Bulgarian();
+        }
+        else if ("Chinese (simplified)".equals(outputLanguage)) {
+            result2 = new Chinese();
+        }
+        else if ("Czech".equals(outputLanguage)) {
+            result2 = new Czech();
+        }
+        else if ("Danish".equals(outputLanguage)) {
+            result2 = new Danish();
+        }
+        else if ("Dutch".equals(outputLanguage)) {
+            result2 = new Dutch();
+        }
+        else if ("English (American)".equals(outputLanguage)) {
+            result2 = new English();
+        }
+        else if ("English (British)".equals(outputLanguage)) {
+            result2 = new English();
+        }
+        else if ("Estonian".equals(outputLanguage)) {
+            result2 = new Estonian();
+        }
+        else if ("Finnish".equals(outputLanguage)) {
+            result2 = new Finnish();
+        }
+        else if ("French".equals(outputLanguage)) {
+            result2 = new French();
+        }
+        else if ("German".equals(outputLanguage)) {
+            result2 = new German();
+        }
+        else if ("Greek".equals(outputLanguage)) {
+            result2 = new Greek();
+        }
+        else if ("Hungarian".equals(outputLanguage)) {
+            result2 = new Hungarian();
+        }
+        else if ("Indonesian".equals(outputLanguage)) {
+            result2 = new Indonesian();
+        }
+        else if ("Italian".equals(outputLanguage)) {
+            result2 = new Italian();
+        }
+        else if ("Japanese".equals(outputLanguage)) {
+            result2 = new Japanese();
+        }
+        else if ("Korean".equals(outputLanguage)) {
+            result2 = new Korean();
+        }
+        else if ("Latvian".equals(outputLanguage)) {
+            result2 = new Latvian();
+        }
+        else if ("Lithuanian".equals(outputLanguage)) {
+            result2 = new Lithuanian();
+        }
+        else if ("Norwegian".equals(outputLanguage)) {
+            result2 = new Norwegian();
+        }
+        else if ("Polish".equals(outputLanguage)) {
+            result2 = new Polish();
+        }
+        else if ("Portuguese (Brazilian)".equals(outputLanguage)) {
+            result2 = new Portuguese();
+        }
+        else if ("Portuguese (European)".equals(outputLanguage)) {
+            result2 = new Portuguese();
+        }
+        else if ("Romanian".equals(outputLanguage)) {
+            result2 = new Romanian();
+        }
+        else if ("Russian".equals(outputLanguage)) {
+            result2 = new Russian();
+        }
+        else if ("Slovak".equals(outputLanguage)) {
+            result2 = new Slovak();
+        }
+        else if ("Slovenian".equals(outputLanguage)) {
+            result2 = new Slovenian();
+        }
+        else if ("Spanish".equals(outputLanguage)) {
+            result2 = new Spanish();
+        }
+        else if ("Swedish".equals(outputLanguage)) {
+            result2 = new Swedish();
+        }
+        else if ("Turkish".equals(outputLanguage)) {
+            result2 = new Turkish();
+        }
+        else if ("Ukrainian".equals(outputLanguage)) {
+            result2 = new Ukrainian();
+        }
+        return result2;
+    }
+}

--- a/src/main/java/data_access/LanguageMapperInterface.java
+++ b/src/main/java/data_access/LanguageMapperInterface.java
@@ -1,0 +1,28 @@
+package data_access;
+
+import use_case.translateText.DataAccessException;
+
+/**
+ * LanguageMapper Interface.
+ */
+
+public interface LanguageMapperInterface {
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     * @throws DataAccessException if the text could not be translated for any reason
+     */
+    String giveOutput(String inputLanguage)
+            throws DataAccessException;
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     * @return what that language will be as an input language
+     * @throws DataAccessException if the text could not be translated for any reason
+     */
+    String giveInput(String outputLanguage)
+            throws DataAccessException;
+}

--- a/src/main/java/languageClasses/Bulgarian.java
+++ b/src/main/java/languageClasses/Bulgarian.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Bulgarian.
+ */
+
+public class Bulgarian implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Bulgarian";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Bulgarian";
+    }
+
+}

--- a/src/main/java/languageClasses/Chinese.java
+++ b/src/main/java/languageClasses/Chinese.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Chinese.
+ */
+
+public class Chinese implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Chinese (simplified)";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Chinese";
+    }
+
+}

--- a/src/main/java/languageClasses/Czech.java
+++ b/src/main/java/languageClasses/Czech.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Czech.
+ */
+
+public class Czech implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Czech";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Czech";
+    }
+
+}

--- a/src/main/java/languageClasses/Danish.java
+++ b/src/main/java/languageClasses/Danish.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Danish.
+ */
+
+public class Danish implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Danish";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Danish";
+    }
+
+}

--- a/src/main/java/languageClasses/Dutch.java
+++ b/src/main/java/languageClasses/Dutch.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Dutch.
+ */
+
+public class Dutch implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Dutch";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Dutch";
+    }
+
+}

--- a/src/main/java/languageClasses/English.java
+++ b/src/main/java/languageClasses/English.java
@@ -1,0 +1,32 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * English.
+ */
+
+public class English implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "English (American)";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "English";
+    }
+
+}
+

--- a/src/main/java/languageClasses/Estonian.java
+++ b/src/main/java/languageClasses/Estonian.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Estonian.
+ */
+
+public class Estonian implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Estonian";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Estonian";
+    }
+
+}

--- a/src/main/java/languageClasses/Finnish.java
+++ b/src/main/java/languageClasses/Finnish.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Finnish.
+ */
+
+public class Finnish implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Finnish";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Finnish";
+    }
+
+}

--- a/src/main/java/languageClasses/French.java
+++ b/src/main/java/languageClasses/French.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * French.
+ */
+
+public class French implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "French";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "French";
+    }
+
+}

--- a/src/main/java/languageClasses/German.java
+++ b/src/main/java/languageClasses/German.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * German.
+ */
+
+public class German implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "German";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "German";
+    }
+
+}

--- a/src/main/java/languageClasses/Greek.java
+++ b/src/main/java/languageClasses/Greek.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Greek.
+ */
+
+public class Greek implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Greek";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Greek";
+    }
+
+}

--- a/src/main/java/languageClasses/Hungarian.java
+++ b/src/main/java/languageClasses/Hungarian.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Hungarian.
+ */
+
+public class Hungarian implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Hungarian";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Hungarian";
+    }
+
+}

--- a/src/main/java/languageClasses/Indonesian.java
+++ b/src/main/java/languageClasses/Indonesian.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Indonesian.
+ */
+
+public class Indonesian implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Indonesian";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Indonesian";
+    }
+
+}

--- a/src/main/java/languageClasses/Italian.java
+++ b/src/main/java/languageClasses/Italian.java
@@ -1,0 +1,32 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Italian.
+ */
+
+public class Italian implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Italian";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Italian";
+    }
+
+}
+

--- a/src/main/java/languageClasses/Japanese.java
+++ b/src/main/java/languageClasses/Japanese.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Japanese.
+ */
+
+public class Japanese implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Japanese";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Japanese";
+    }
+
+}

--- a/src/main/java/languageClasses/Korean.java
+++ b/src/main/java/languageClasses/Korean.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Korean.
+ */
+
+public class Korean implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Korean";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Korean";
+    }
+
+}

--- a/src/main/java/languageClasses/Latvian.java
+++ b/src/main/java/languageClasses/Latvian.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Latvian.
+ */
+
+public class Latvian implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Latvian";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Latvian";
+    }
+
+}

--- a/src/main/java/languageClasses/Lithuanian.java
+++ b/src/main/java/languageClasses/Lithuanian.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Lithuanian.
+ */
+
+public class Lithuanian implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Lithuanian";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Lithuanian";
+    }
+
+}

--- a/src/main/java/languageClasses/Norwegian.java
+++ b/src/main/java/languageClasses/Norwegian.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Norwegian.
+ */
+
+public class Norwegian implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Norwegian";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Norwegian";
+    }
+
+}

--- a/src/main/java/languageClasses/Polish.java
+++ b/src/main/java/languageClasses/Polish.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Polish.
+ */
+
+public class Polish implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Polish";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Polish";
+    }
+
+}

--- a/src/main/java/languageClasses/Portuguese.java
+++ b/src/main/java/languageClasses/Portuguese.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Portuguese.
+ */
+
+public class Portuguese implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Portuguese (Brazilian)";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Portuguese";
+    }
+
+}

--- a/src/main/java/languageClasses/Romanian.java
+++ b/src/main/java/languageClasses/Romanian.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Romanian.
+ */
+
+public class Romanian implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Romanian";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Romanian";
+    }
+
+}

--- a/src/main/java/languageClasses/Russian.java
+++ b/src/main/java/languageClasses/Russian.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Russian.
+ */
+
+public class Russian implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Russian";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Russian";
+    }
+
+}

--- a/src/main/java/languageClasses/Slovak.java
+++ b/src/main/java/languageClasses/Slovak.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Slovak.
+ */
+
+public class Slovak implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Slovak";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Slovak";
+    }
+
+}

--- a/src/main/java/languageClasses/Slovenian.java
+++ b/src/main/java/languageClasses/Slovenian.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Slovenian.
+ */
+
+public class Slovenian implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Slovenian";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Slovenian";
+    }
+
+}

--- a/src/main/java/languageClasses/Spanish.java
+++ b/src/main/java/languageClasses/Spanish.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Spanish.
+ */
+
+public class Spanish implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Spanish";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Spanish";
+    }
+
+}

--- a/src/main/java/languageClasses/Swedish.java
+++ b/src/main/java/languageClasses/Swedish.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Swedish.
+ */
+
+public class Swedish implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Swedish";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Swedish";
+    }
+
+}

--- a/src/main/java/languageClasses/Turkish.java
+++ b/src/main/java/languageClasses/Turkish.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Turkish.
+ */
+
+public class Turkish implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Turkish";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Turkish";
+    }
+
+}

--- a/src/main/java/languageClasses/Ukrainian.java
+++ b/src/main/java/languageClasses/Ukrainian.java
@@ -1,0 +1,31 @@
+package languageClasses;
+
+import data_access.LanguageMapperInterface;
+
+/**
+ * Ukrainian.
+ */
+
+public class Ukrainian implements LanguageMapperInterface {
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     * @param inputLanguage  the language name of text (ie. English). Set to null to detect language.
+     * @return what that language will be as an output language
+     */
+    @Override
+    public String giveOutput(String inputLanguage) {
+        return "Ukrainian";
+    }
+
+    /**
+     * Given an input language, return what it will be when that language an output language.
+     *
+     * @param outputLanguage the language name (ie. English (American)) to which the text is translated
+     */
+    @Override
+    public String giveInput(String outputLanguage) {
+        return "Ukrainian";
+    }
+
+}


### PR DESCRIPTION
I created an interface that contains two methods that used to be in the DB file but violated the open/closed principle. If we added a new language I used to have to modify that method but now I simply create a new class and the interface handles everything. So, I created classes for all the languages and an additional class to aid in mapping an input language to an output language and vice-versa. 